### PR TITLE
Dev

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src

--- a/src/Services/ChatService.cs
+++ b/src/Services/ChatService.cs
@@ -1,5 +1,5 @@
-using Azure;
 using Azure.AI.Inference;
+using Azure.Identity;
 
 namespace ZavaStorefront.Services;
 
@@ -15,12 +15,16 @@ public class ChatService
 
         _endpoint = configuration["AzureAIFoundry:Endpoint"]
             ?? throw new InvalidOperationException("AzureAIFoundry:Endpoint is not configured.");
-        var apiKey = configuration["AzureAIFoundry:ApiKey"]
-            ?? throw new InvalidOperationException("AzureAIFoundry:ApiKey is not configured.");
+
+        // DefaultAzureCredential uses managed identity (via AZURE_CLIENT_ID) on Azure
+        // and falls back to Azure CLI / developer credentials when running locally.
+        var clientId = configuration["AZURE_CLIENT_ID"];
+        var credential = new DefaultAzureCredential(
+            new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId });
 
         _client = new ChatCompletionsClient(
             new Uri(_endpoint),
-            new AzureKeyCredential(apiKey));
+            credential);
     }
 
     public async Task<string> SendMessageAsync(string userMessage)

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -7,7 +7,6 @@
   },
   "AllowedHosts": "*",
   "AzureAIFoundry": {
-    "Endpoint": "",
-    "ApiKey": ""
+    "Endpoint": ""
   }
 }


### PR DESCRIPTION
This pull request updates authentication for the Azure AI Foundry integration to exclusively use Azure Entra ID (managed identity) instead of API key authentication. It also includes a minor change to the Dockerfile's exposed port. The most important changes are:

**Authentication and Authorization Updates:**

* Removed API key configuration and usage for Azure AI Foundry, both in infrastructure (`core.bicep`) and application code (`ChatService.cs`, `appsettings.json`). The service now relies solely on Azure Entra ID (managed identity) for authentication. [[1]](diffhunk://#diff-bb252ff5cc078930147492cadced05d7c53b7392fc1ce763cd6b58b2e98108c8L125-L128) [[2]](diffhunk://#diff-544e56af2d1cfab367d34f1f3de5aa610f4f6fe260325cc58cc07ab8017127fbL18-R27) [[3]](diffhunk://#diff-4f3092c803fde3de70bbd69d14f1156cf031d668c8696dcdaa21c83eb0aaa04cL10-R10)
* Updated the AI Foundry resource definition to disable local (API key) authentication and enforce Entra ID as the only supported method.
* Added a role assignment in the infrastructure to grant the application's managed identity the "Azure AI User" role on the AI Foundry resource, enabling token-based authentication.

**Application Code Changes:**

* Refactored the `ChatService` to use `DefaultAzureCredential` (managed identity) instead of an API key for authenticating with the Azure AI Inference client.

**DevOps/Containerization:**

* Changed the exposed port in the Dockerfile from 80/443 to 8080 to match the application's configuration or deployment requirements.